### PR TITLE
fix (docs): Update API endpoint documentation and workflow details

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ go run ./cmd/api
 
 Full route reference:
 
-- [docs/endpoint.md](/home/bastou/delivery/eip/OD_Backend/docs/endpoint.md)
+- [docs/endpoint.md](/docs/endpoint.md)
 
 Example flow:
 

--- a/README.md
+++ b/README.md
@@ -92,31 +92,60 @@ Current backend entrypoint:
 go run ./cmd/api
 ```
 
-### Available endpoints
+### Navigation model
 
-- `GET /health`
-- `GET /getrace` (legacy alias)
-- `POST /sendrace` (legacy alias)
-- `GET /api/v1/race/getrace`
-- `POST /api/v1/race/sendrace`
-- `GET /api/v1/race/cache`
-- `GET /api/v1/race/storage`
-- `GET /api/v1/race/championship/drivers`
-- `GET /api/v1/race/championship/constructors`
-- `GET /api/v1/race/weather`
-- `GET /api/v1/race/facts`
-- `GET /api/v1/race/driver?driver_number=63`
-- `GET /api/v1/race/standings/race`
-- `GET /api/v1/race/video-url`
+- `Provider -> Championship -> Event -> Session`
+- Session-scoped endpoints are the preferred read API.
+- `/api/v1/race/*` endpoints are convenience routes resolved against the merged latest stored session.
+
+### Main endpoint groups
+
+- Health:
+  - `GET /`
+  - `GET /health`
+- Ingestion:
+  - `GET /getrace`
+  - `GET /api/v1/race/getrace`
+- Catalog:
+  - `GET /api/v1/championships`
+  - `GET /api/v1/championships/{code}/events`
+  - `GET /api/v1/events/{eventId}`
+  - `GET /api/v1/events/{eventId}/sessions`
+  - `GET /api/v1/sessions/{sessionId}`
+- Session-scoped reads:
+  - `GET /api/v1/sessions/{sessionId}/archive`
+  - `GET /api/v1/sessions/{sessionId}/datasets/{dataset}`
+  - `GET /api/v1/sessions/{sessionId}/drivers`
+  - `GET /api/v1/sessions/{sessionId}/drivers/{driverNumber}/profile`
+  - `GET /api/v1/sessions/{sessionId}/broadcast`
+  - `GET /api/v1/sessions/{sessionId}/drivers/{driverNumber}/broadcast`
+- Latest-session convenience reads:
+  - `GET|POST /sendrace`
+  - `GET|POST /api/v1/race/sendrace`
+  - `GET /api/v1/race/datasets/{dataset}`
+  - `GET /api/v1/race/championship/drivers`
+  - `GET /api/v1/race/championship/constructors`
+  - `GET /api/v1/race/weather`
+  - `GET /api/v1/race/facts`
+  - `GET /api/v1/race/standings/race`
+  - `GET /api/v1/race/video-url`
+
+Full route reference:
+
+- [docs/endpoint.md](/home/bastou/delivery/eip/OD_Backend/docs/endpoint.md)
 
 Example flow:
 
 ```bash
 # 1) fetch from OpenF1 and persist in PostgreSQL
-curl "http://localhost:8080/api/v1/race/getrace?year=2025&country=Australia&meeting=Australian%20Grand%20Prix&driver_number=63"
+curl "http://localhost:8080/api/v1/race/getrace?year=2025&country=Australia&meeting=Australian%20Grand%20Prix&driver_number=0"
 
-# 2) send latest stored payload
-curl -X POST "http://localhost:8080/api/v1/race/sendrace"
+# 2) browse catalog
+curl "http://localhost:8080/api/v1/championships/f1/events"
+
+# 3) read one stored session explicitly
+curl "http://localhost:8080/api/v1/events/<EVENT_ID>/sessions"
+curl "http://localhost:8080/api/v1/sessions/<SESSION_ID>/datasets/session_result"
 ```
 
 <br>

--- a/docs/endpoint.md
+++ b/docs/endpoint.md
@@ -5,10 +5,13 @@ Base URL: `http://localhost:8080`
 ## Notes
 
 - `GET /getrace` or `GET /api/v1/race/getrace` must be called first to fetch and store data.
-- Read endpoints use the merged latest session view, so several driver imports are aggregated together.
-- Historical navigation is now supported through explicit session-scoped endpoints.
+- Session-scoped endpoints are the preferred read API because they target one explicit stored session.
+- `/api/v1/race/*` endpoints are legacy convenience routes that resolve against the merged latest stored session.
+- Latest-session reads use the merged latest session view, so several driver imports are aggregated together.
 - Recommended navigation flow: `provider -> championship -> event -> session -> session-scoped data endpoints`.
 - Legacy routes are still available for `/getrace` and `/sendrace`.
+- Dataset rows that expose `driver_number` are enriched with `driver_name` and `team_name` when the corresponding driver exists in the stored session.
+- There is currently no dedicated `GET /api/v1/championships/{code}/drivers` or `GET /api/v1/championships/{code}/teams` endpoint.
 
 ## Health
 
@@ -48,6 +51,9 @@ Base URL: `http://localhost:8080`
 
 - `GET /api/v1/sessions/{sessionId}/datasets/{dataset}`
   - Returns one merged dataset for one explicit session.
+  - Rows containing `driver_number` are enriched with:
+    - `driver_name`
+    - `team_name`
   - Supported dataset values:
     - `drivers`
     - `laps`
@@ -87,16 +93,18 @@ Base URL: `http://localhost:8080`
 - `GET /api/v1/sessions/{sessionId}/drivers/{driverNumber}/broadcast`
   - Returns the driver-specific broadcast URL stored for one explicit session.
 
-- `GET /api/v1/sessions/{sessionId}/drivers/{driverNumber}/laps`
-- `GET /api/v1/sessions/{sessionId}/drivers/{driverNumber}/telemetry`
-- `GET /api/v1/sessions/{sessionId}/drivers/{driverNumber}/location`
-- `GET /api/v1/sessions/{sessionId}/drivers/{driverNumber}/position`
-- `GET /api/v1/sessions/{sessionId}/drivers/{driverNumber}/intervals`
-- `GET /api/v1/sessions/{sessionId}/drivers/{driverNumber}/stints`
-- `GET /api/v1/sessions/{sessionId}/drivers/{driverNumber}/pit`
-- `GET /api/v1/sessions/{sessionId}/drivers/{driverNumber}/radio`
-- `GET /api/v1/sessions/{sessionId}/drivers/{driverNumber}/result`
+- `GET /api/v1/sessions/{sessionId}/drivers/{driverNumber}/{resource}`
   - Return one driver-scoped dataset for one driver in one explicit session.
+  - Supported resource values:
+    - `laps`
+    - `telemetry`
+    - `location`
+    - `position`
+    - `intervals`
+    - `stints`
+    - `pit`
+    - `radio`
+    - `result`
 
 - `GET /api/v1/sessions/{sessionId}/weather`
   - Returns weather samples for one explicit session.
@@ -127,7 +135,7 @@ Base URL: `http://localhost:8080`
 - `GET /api/v1/race/storage`
   - Returns storage status for the latest session import.
 
-## Full Race Payload
+## Latest-Session Convenience Endpoints
 
 - `GET /sendrace`
 - `POST /sendrace`
@@ -145,6 +153,9 @@ Base URL: `http://localhost:8080`
 
 - `GET /api/v1/race/datasets/{dataset}`
   - Returns one merged dataset by name.
+  - Rows containing `driver_number` are enriched with:
+    - `driver_name`
+    - `team_name`
   - Supported dataset values:
     - `drivers`
     - `laps`
@@ -169,36 +180,46 @@ Base URL: `http://localhost:8080`
     - `championship_teams`
     - `constructors`
 
-## Drivers
+## Latest-Session Driver And Team Endpoints
 
 - `GET /api/v1/race/drivers`
   - Returns the merged list of drivers available in the latest stored session.
 
-- `GET /api/v1/race/drivers/{driverNumber}`
-  - Returns the full latest-session payload for one driver.
-  - Includes profile, counts, and all driver-scoped datasets.
-
-- `GET /api/v1/race/drivers/{driverNumber}/profile`
-  - Returns the driver profile only.
-
-- `GET /api/v1/race/drivers/{driverNumber}/laps`
-- `GET /api/v1/race/drivers/{driverNumber}/telemetry`
-- `GET /api/v1/race/drivers/{driverNumber}/location`
-- `GET /api/v1/race/drivers/{driverNumber}/position`
-- `GET /api/v1/race/drivers/{driverNumber}/intervals`
-- `GET /api/v1/race/drivers/{driverNumber}/stints`
-- `GET /api/v1/race/drivers/{driverNumber}/pit`
-- `GET /api/v1/race/drivers/{driverNumber}/radio`
-- `GET /api/v1/race/drivers/{driverNumber}/result`
-  - Return one driver-scoped dataset for one driver.
-
-- `GET /api/v1/race/driver?driver_number={driverNumber}`
-  - Legacy endpoint returning the full latest-session payload for one driver.
-
-## Teams
-
 - `GET /api/v1/race/teams`
   - Returns teams inferred from the merged drivers dataset.
+
+- `GET /api/v1/race/drivers/{driverNumber}`
+  - Returns the full latest-session payload for one driver.
+
+- `GET /api/v1/race/drivers/{driverNumber}/profile`
+  - Returns the driver profile only for the merged latest stored session.
+
+- `GET /api/v1/race/drivers/{driverNumber}/{resource}`
+  - Latest-session mirror of the session-scoped driver dataset endpoint.
+  - It resolves data against the merged latest stored session instead of an explicit `sessionId`.
+  - Supported resource values:
+    - `laps`
+    - `telemetry`
+    - `location`
+    - `position`
+    - `intervals`
+    - `stints`
+    - `pit`
+    - `radio`
+    - `result`
+
+- `GET /api/v1/race/driver?driver_number={driverNumber}`
+  - Legacy query-param variant returning the full latest-session payload for one driver.
+
+## Championship Participants
+
+- There is no dedicated `GET /api/v1/championships/{code}/drivers` endpoint yet.
+- There is no dedicated `GET /api/v1/championships/{code}/teams` endpoint yet.
+- Current workaround:
+  - `GET /api/v1/championships/{code}/events`
+  - `GET /api/v1/events/{eventId}/sessions`
+  - `GET /api/v1/sessions/{sessionId}/drivers`
+  - `GET /api/v1/sessions/{sessionId}/teams`
 
 ## Championship
 
@@ -232,13 +253,13 @@ Base URL: `http://localhost:8080`
 curl "http://localhost:8080/api/v1/championships"
 curl "http://localhost:8080/api/v1/championships/f1/events"
 curl "http://localhost:8080/api/v1/race/getrace?year=2025&country=Australia&meeting=Australian%20Grand%20Prix&driver_number=0"
-curl "http://localhost:8080/api/v1/events/event-aus-2025/sessions"
-curl "http://localhost:8080/api/v1/sessions/session-race-9693/archive"
-curl "http://localhost:8080/api/v1/sessions/session-race-9693/drivers"
-curl "http://localhost:8080/api/v1/sessions/session-race-9693/drivers/63/broadcast"
-curl "http://localhost:8080/api/v1/race/drivers"
-curl "http://localhost:8080/api/v1/race/drivers/63/profile"
-curl "http://localhost:8080/api/v1/race/drivers/63/telemetry"
+curl "http://localhost:8080/api/v1/events/<EVENT_ID>/sessions"
+curl "http://localhost:8080/api/v1/sessions/<SESSION_ID>/archive"
+curl "http://localhost:8080/api/v1/sessions/<SESSION_ID>/drivers"
+curl "http://localhost:8080/api/v1/sessions/<SESSION_ID>/datasets/championship_drivers"
+curl "http://localhost:8080/api/v1/sessions/<SESSION_ID>/datasets/session_result"
+curl "http://localhost:8080/api/v1/sessions/<SESSION_ID>/drivers/63/broadcast"
+curl "http://localhost:8080/api/v1/race/sendrace"
 curl "http://localhost:8080/api/v1/race/datasets/weather"
 curl "http://localhost:8080/api/v1/race/standings/race?at=2025-03-16T04:45:00Z"
 ```

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -69,7 +69,7 @@ OD_Backend/
 │   │   ├── catalog.go
 │   │   │  Role:
 │   │   │  - Domain types for catalog navigation.
-│   │   │  - Defines championship, race, and session summaries exposed by the API.
+│   │   │  - Defines championship, event, and session summaries exposed by the API.
 │   │   │  - Includes session-level broadcast URL metadata.
 │   │   │
 │   │   └── race_archive.go

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -24,7 +24,7 @@ Scope:
 3. [`RaceService.FetchAndStore`](/home/bastou/delivery/eip/OD_Backend/internal/service/race_service.go:38) serializes concurrent fetches
 4. [`RaceBuilder.Build`](/home/bastou/delivery/eip/OD_Backend/internal/usecase/build_race.go:44) calls OpenF1 and builds a `domain.RaceArchive`
 5. [`RaceArchiveStore.Store`](/home/bastou/delivery/eip/OD_Backend/internal/repository/prisma/race_archive_store.go:50) persists:
-   - provider/championship/event/race/session metadata
+   - provider/championship/event/session metadata
    - chunked raw archive datasets in `RaceDatasetChunk`
    - normalized race tables in the same atomic write flow
 
@@ -32,7 +32,6 @@ Scope:
 
 1. Client calls either:
    - `/api/v1/race/sendrace`
-   - `/api/v1/race/drivers`
    - `/api/v1/race/standings/race`
    - `/api/v1/sessions/{sessionId}/archive`
    - `/api/v1/sessions/{sessionId}/drivers`
@@ -382,7 +381,7 @@ This file centralizes the small reusable helpers used across all repository file
 
 | Function | Purpose | Why it exists |
 |---|---|---|
-| `inferEventBounds` | Infers temporal bounds from archive rows. | Gives event/race/session rows consistent start and end values. |
+| `inferEventBounds` | Infers temporal bounds from archive rows. | Gives event and session rows consistent start and end values. |
 | `resolveArchiveMode` | Resolves full vs driver-focused import mode. | Persists the archive import strategy. |
 | `resolveEventStatus` | Resolves event lifecycle status. | Normalizes provider data into DB enum values. |
 | `resolveSessionType` | Resolves session type from session name. | Maps provider naming to DB enum values. |

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -14,16 +14,16 @@ Scope:
 
 1. Developer starts the backend through a local script or directly with `go run ./cmd/api`
 2. PostgreSQL must already be available and `DATABASE_URL` must be set
-3. [`main.go`](/home/bastou/delivery/eip/OD_Backend/cmd/api/main.go) loads config, connects DB, builds server, starts HTTP
+3. [`main.go`](/cmd/api/main.go) loads config, connects DB, builds server, starts HTTP
 4. The default `driver-number` CLI flag is `0`, so ingestion is full-race by default unless one driver is explicitly requested
 
 ### 2. Write flow: fetch and store a race
 
 1. Client calls `GET /api/v1/race/getrace`
-2. [`RaceHandler.HandleGetRace`](/home/bastou/delivery/eip/OD_Backend/internal/api/race_handler.go:284) parses query params
-3. [`RaceService.FetchAndStore`](/home/bastou/delivery/eip/OD_Backend/internal/service/race_service.go:38) serializes concurrent fetches
-4. [`RaceBuilder.Build`](/home/bastou/delivery/eip/OD_Backend/internal/usecase/build_race.go:44) calls OpenF1 and builds a `domain.RaceArchive`
-5. [`RaceArchiveStore.Store`](/home/bastou/delivery/eip/OD_Backend/internal/repository/prisma/race_archive_store.go:50) persists:
+2. [`RaceHandler.HandleGetRace`](/internal/api/race_handler.go:284) parses query params
+3. [`RaceService.FetchAndStore`](/internal/service/race_service.go:38) serializes concurrent fetches
+4. [`RaceBuilder.Build`](/internal/usecase/build_race.go:44) calls OpenF1 and builds a `domain.RaceArchive`
+5. [`RaceArchiveStore.Store`](/internal/repository/prisma/race_archive_store.go:50) persists:
    - provider/championship/event/session metadata
    - chunked raw archive datasets in `RaceDatasetChunk`
    - normalized race tables in the same atomic write flow
@@ -275,7 +275,7 @@ When a read endpoint asks for stored race data, the repository flow is:
 2. `archiveFromModel`, `mergeArchiveModels`, or direct catalog/broadcast lookup
 3. handlers serialize the rebuilt domain archive
 
-### [`race_archive_store.go`](/home/bastou/delivery/eip/OD_Backend/internal/repository/prisma/race_archive_store.go)
+### [`race_archive_store.go`](/internal/repository/prisma/race_archive_store.go)
 
 This file contains the repository entrypoints and the high-level store flow.
 
@@ -287,7 +287,7 @@ This file contains the repository entrypoints and the high-level store flow.
 | `(*RaceArchiveStore).GetLatestMerged` | Rebuilds a merged archive for the latest session. | Prevents losing prior driver-focused imports on read. |
 | `(*RaceArchiveStore).GetSessionMerged` | Rebuilds a merged archive for one explicit session. | Powers historical reads without relying on the latest session pointer. |
 
-### [`race_archive_catalog.go`](/home/bastou/delivery/eip/OD_Backend/internal/repository/prisma/race_archive_catalog.go)
+### [`race_archive_catalog.go`](/internal/repository/prisma/race_archive_catalog.go)
 
 This file owns all read-side catalog queries and archive reconstruction logic.
 
@@ -305,7 +305,7 @@ This file owns all read-side catalog queries and archive reconstruction logic.
 | `eventSummaryFromModel` | Maps Prisma event model to domain summary. | Same reason. |
 | `(*RaceArchiveStore).sessionSummaryFromModel` | Maps Prisma session model to domain summary. | Same reason. |
 
-### [`race_archive_entities.go`](/home/bastou/delivery/eip/OD_Backend/internal/repository/prisma/race_archive_entities.go)
+### [`race_archive_entities.go`](/internal/repository/prisma/race_archive_entities.go)
 
 This file owns top-level metadata upserts before any race payload is written.
 
@@ -316,7 +316,7 @@ This file owns top-level metadata upserts before any race payload is written.
 | `(*RaceArchiveStore).ensureEvent` | Ensures the event row exists for the imported archive. | Materializes the `championship -> event` relation from provider meeting data. |
 | `(*RaceArchiveStore).ensureSession` | Ensures the session row exists. | Materializes the `event -> session` relation. |
 
-### [`race_archive_participants.go`](/home/bastou/delivery/eip/OD_Backend/internal/repository/prisma/race_archive_participants.go)
+### [`race_archive_participants.go`](/internal/repository/prisma/race_archive_participants.go)
 
 This file owns raw chunk persistence and team/driver synchronization.
 
@@ -329,7 +329,7 @@ This file owns raw chunk persistence and team/driver synchronization.
 | `(*RaceArchiveStore).ensureTeam` | Upserts one team inferred from driver data. | Keeps team rows consistent across imports. |
 | `(*RaceArchiveStore).ensureDriver` | Upserts one driver inferred from driver data. | Keeps driver rows consistent across imports. |
 
-### [`race_archive_normalized.go`](/home/bastou/delivery/eip/OD_Backend/internal/repository/prisma/race_archive_normalized.go)
+### [`race_archive_normalized.go`](/internal/repository/prisma/race_archive_normalized.go)
 
 This file owns cleanup and normalized inserts into race-specific tables.
 
@@ -373,7 +373,7 @@ This file owns cleanup and normalized inserts into race-specific tables.
 | `executeDatasetInsert` | Runs one raw SQL JSON insert immediately. | Shared low-level insert helper for direct writes. |
 | `executeDatasetInsertTx` | Builds one raw SQL JSON insert transaction. | Shared low-level insert helper for atomic writes. |
 
-### [`race_archive_helpers.go`](/home/bastou/delivery/eip/OD_Backend/internal/repository/prisma/race_archive_helpers.go)
+### [`race_archive_helpers.go`](/internal/repository/prisma/race_archive_helpers.go)
 
 This file centralizes the small reusable helpers used across all repository files.
 
@@ -452,16 +452,16 @@ If you want to understand the backend quickly, keep this map in mind:
 
 ## Suggested Reading Order
 
-1. [`cmd/api/main.go`](/home/bastou/delivery/eip/OD_Backend/cmd/api/main.go)
-2. [`internal/app/server.go`](/home/bastou/delivery/eip/OD_Backend/internal/app/server.go)
-3. [`internal/api/router.go`](/home/bastou/delivery/eip/OD_Backend/internal/api/router.go)
-4. [`internal/api/race_handler.go`](/home/bastou/delivery/eip/OD_Backend/internal/api/race_handler.go)
-5. [`internal/service/race_service.go`](/home/bastou/delivery/eip/OD_Backend/internal/service/race_service.go)
-6. [`internal/usecase/build_race.go`](/home/bastou/delivery/eip/OD_Backend/internal/usecase/build_race.go)
-7. [`internal/repository/prisma/race_archive_store.go`](/home/bastou/delivery/eip/OD_Backend/internal/repository/prisma/race_archive_store.go)
-8. [`internal/repository/prisma/race_archive_catalog.go`](/home/bastou/delivery/eip/OD_Backend/internal/repository/prisma/race_archive_catalog.go)
-9. [`internal/repository/prisma/race_archive_entities.go`](/home/bastou/delivery/eip/OD_Backend/internal/repository/prisma/race_archive_entities.go)
-10. [`internal/repository/prisma/race_archive_participants.go`](/home/bastou/delivery/eip/OD_Backend/internal/repository/prisma/race_archive_participants.go)
-11. [`internal/repository/prisma/race_archive_normalized.go`](/home/bastou/delivery/eip/OD_Backend/internal/repository/prisma/race_archive_normalized.go)
-12. [`internal/repository/prisma/race_archive_helpers.go`](/home/bastou/delivery/eip/OD_Backend/internal/repository/prisma/race_archive_helpers.go)
-13. [`internal/providers/openf1/client.go`](/home/bastou/delivery/eip/OD_Backend/internal/providers/openf1/client.go)
+1. [`cmd/api/main.go`](/cmd/api/main.go)
+2. [`internal/app/server.go`](/internal/app/server.go)
+3. [`internal/api/router.go`](/internal/api/router.go)
+4. [`internal/api/race_handler.go`](/internal/api/race_handler.go)
+5. [`internal/service/race_service.go`](/internal/service/race_service.go)
+6. [`internal/usecase/build_race.go`](/internal/usecase/build_race.go)
+7. [`internal/repository/prisma/race_archive_store.go`](/internal/repository/prisma/race_archive_store.go)
+8. [`internal/repository/prisma/race_archive_catalog.go`](/internal/repository/prisma/race_archive_catalog.go)
+9. [`internal/repository/prisma/race_archive_entities.go`](/internal/repository/prisma/race_archive_entities.go)
+10. [`internal/repository/prisma/race_archive_participants.go`](/internal/repository/prisma/race_archive_participants.go)
+11. [`internal/repository/prisma/race_archive_normalized.go`](/internal/repository/prisma/race_archive_normalized.go)
+12. [`internal/repository/prisma/race_archive_helpers.go`](/internal/repository/prisma/race_archive_helpers.go)
+13. [`internal/providers/openf1/client.go`](/internal/providers/openf1/client.go)


### PR DESCRIPTION
## Summary

Refresh the project documentation so it matches the current backend implementation and routing model.

## Context

The documentation was partially outdated after the backend refactor:
- the data navigation model changed to `Provider -> Championship -> Event -> Session`
- session-scoped endpoints became the preferred read API

## Scope

This PR updates documentation only.

## Changes

- updated `docs/endpoint.md`
- updated `docs/workflow.md`
- updated `docs/tree.md`
- updated `README.md`

## Impact

- easier onboarding
- lower risk of using stale routes or outdated examples
- documentation now reflects the real backend behavior

## Breaking Changes

None.

## Validation

None.

## Review Notes

only docs so only need to read the change

## Rollback Notes

If needed, rollback is trivial because this PR only changes documentation files.
