### PR TITLE
feat (gateway/): add exposure of race live  endpoints

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -57,24 +57,31 @@ Invalid token example:
 curl -i -H "Authorization: Bearer invalid" http://localhost:3000/health
 ```
 
-Proxied API example:
+Proxied API examples:
 
 ```bash
 curl -i -H "Authorization: Bearer ${GATEWAY_TOKEN}" \
   http://localhost:3000/v1/championship/championships
+
+curl -i -H "Authorization: Bearer ${GATEWAY_TOKEN}" \
+  http://localhost:3000/v1/race/championships
 ```
 
-Dataset validation example:
+Dataset validation examples:
 
 ```bash
 curl -i -H "Authorization: Bearer ${GATEWAY_TOKEN}" \
   http://localhost:3000/v1/championship/sessions/123/datasets/not_allowed
+
+curl -i -H "Authorization: Bearer ${GATEWAY_TOKEN}" \
+  http://localhost:3000/v1/race/sessions/123/drivers/not_a_number/profile
 ```
 
 ## Routes
 
 - Full route mapping: [ROUTES.md](./ROUTES.md)
 - Championship public facade: `/v1/championship/*` -> `championship-service`
+- Race public facade: `/v1/race/*` -> `race-data-service`
 
 ## Hexagonal Architecture (simple)
 
@@ -107,6 +114,10 @@ Applied at gateway level:
 Additional route-specific validation:
 
 - `/v1/championship/sessions/{sessionId}/datasets/{dataset}` validates dataset enum at gateway edge
+- `/v1/race/sessions/{sessionId}/datasets/{dataset}` validates race dataset enum at gateway edge
+- `/v1/race/sessions/{sessionId}/drivers/{driverNumber}/{segment}` validates `segment` (driver dataset or `profile`/`broadcast`) at gateway edge
+- `/v1/race/sessions/{sessionId}/drivers/{driverNumber}/...` validates `driverNumber` is a positive integer
+- `/v1/race/sessions/{sessionId}/drivers/{driverNumber}/laps/{lapNumber}/location` validates `lapNumber` is a positive integer
 
 If no `Authorization` header is provided, request is allowed.
 If an `Authorization` header is provided, it must match the configured token.

--- a/gateway/ROUTES.md
+++ b/gateway/ROUTES.md
@@ -52,8 +52,9 @@ Forwarded/proxy headers added by gateway:
 | User data | `/users` | `USER_DATA_SERVICE_URLS` | prefix stripped |
 | Championship | `/championships` | `CHAMPIONSHIP_SERVICE_URLS` | prefix stripped |
 | Championship v1 facade | `/v1/championship` | `CHAMPIONSHIP_SERVICE_URLS` | prefix stripped |
-| Race data | `/race-data` | `RACE_DATA_SERVICE_URLS` | prefix stripped |
-| Race data | `/races` | `RACE_DATA_SERVICE_URLS` | prefix stripped |
+| Race data (internal) | `/race-data` | `RACE_DATA_SERVICE_URLS` | prefix stripped |
+| Race data (internal) | `/races` | `RACE_DATA_SERVICE_URLS` | prefix stripped |
+| Race data v1 facade | `/v1/race` | `RACE_DATA_SERVICE_URLS` | prefix stripped |
 | Ingestion (internal) | `/ingestion` | `INGESTION_SERVICE_URLS` | prefix stripped |
 
 ## Championship V1 Public Endpoints
@@ -97,6 +98,94 @@ If `{dataset}` is not in this list, gateway returns:
 - status `400`
 - body `{ "error": "invalid parameter" }`
 
+## Race V1 Public Endpoints
+
+All routes below are exposed by gateway under `/v1/race/*` and proxied to `race-data-service`.
+
+### Catalog
+
+| Gateway | Upstream |
+| --- | --- |
+| `GET /v1/race/championships` | `GET /championships` |
+| `GET /v1/race/championships/{code}/events` | `GET /championships/{code}/events` |
+| `GET /v1/race/events/{eventId}` | `GET /events/{eventId}` |
+| `GET /v1/race/events/{eventId}/sessions` | `GET /events/{eventId}/sessions` |
+
+### Session Metadata And References
+
+| Gateway | Upstream |
+| --- | --- |
+| `GET /v1/race/sessions/{sessionId}` | `GET /sessions/{sessionId}` |
+| `GET /v1/race/sessions/{sessionId}/metadata` | `GET /sessions/{sessionId}/metadata` |
+| `GET /v1/race/sessions/{sessionId}/drivers` | `GET /sessions/{sessionId}/drivers` |
+| `GET /v1/race/sessions/{sessionId}/teams` | `GET /sessions/{sessionId}/teams` |
+
+### Session Data And Shortcuts
+
+| Gateway | Upstream |
+| --- | --- |
+| `GET /v1/race/sessions/{sessionId}/datasets/{dataset}` | `GET /sessions/{sessionId}/datasets/{dataset}` |
+| `GET /v1/race/sessions/{sessionId}/standings/race` | `GET /sessions/{sessionId}/standings/race` |
+| `GET /v1/race/sessions/{sessionId}/broadcast` | `GET /sessions/{sessionId}/broadcast` |
+| `GET /v1/race/sessions/{sessionId}/weather` | `GET /sessions/{sessionId}/weather` |
+| `GET /v1/race/sessions/{sessionId}/facts` | `GET /sessions/{sessionId}/facts` |
+
+Gateway validates `{dataset}` for this route against:
+
+- `laps`
+- `car_data`
+- `telemetry`
+- `location`
+- `position`
+- `intervals`
+- `stints`
+- `pit`
+- `pit_stops`
+- `weather`
+- `team_radio`
+- `overtakes`
+- `race_control`
+- `session_result`
+- `starting_grid`
+- `championship_drivers`
+- `championship_teams`
+
+### Driver
+
+| Gateway | Upstream |
+| --- | --- |
+| `GET /v1/race/sessions/{sessionId}/drivers/{driverNumber}/profile` | `GET /sessions/{sessionId}/drivers/{driverNumber}/profile` |
+| `GET /v1/race/sessions/{sessionId}/drivers/{driverNumber}/broadcast` | `GET /sessions/{sessionId}/drivers/{driverNumber}/broadcast` |
+| `GET /v1/race/sessions/{sessionId}/drivers/{driverNumber}/{dataset}` | `GET /sessions/{sessionId}/drivers/{driverNumber}/{dataset}` |
+| `GET /v1/race/sessions/{sessionId}/drivers/{driverNumber}/laps/{lapNumber}/location` | `GET /sessions/{sessionId}/drivers/{driverNumber}/laps/{lapNumber}/location` |
+
+Supported driver datasets on `/drivers/{driverNumber}/{dataset}`:
+
+- `laps`
+- `telemetry`
+- `location`
+- `position`
+- `intervals`
+- `stints`
+- `pit`
+- `radio`
+- `result`
+
+### WebSocket Live
+
+| Gateway | Upstream |
+| --- | --- |
+| `WS /v1/race/live?sessionId={sessionId}` | `WS /live?sessionId={sessionId}` |
+
+### Parameter Validation
+
+Gateway returns `400` with `{ "error": "invalid parameter" }` when one of these values is invalid on `/v1/race/*`:
+
+- `dataset` for `/sessions/{sessionId}/datasets/{dataset}`
+- `segment` for `/drivers/{driverNumber}/{segment}` (allowed: driver datasets + `profile` + `broadcast`)
+- `driverNumber` when present on a driver path (must be a positive integer)
+- `lapNumber` on `/drivers/{driverNumber}/laps/{lapNumber}/location` (must be a positive integer)
+
 ## Error Handling Notes
 
 - Upstream service responses are passed through as-is (including status code and body).
@@ -104,6 +193,7 @@ If `{dataset}` is not in this list, gateway returns:
   - `401` invalid provided auth header
   - `429` rate limit exceeded
   - `400` invalid championship dataset parameter on v1 dataset route
+  - `400` invalid race v1 parameter (`dataset`, `driverNumber`, `lapNumber`)
   - `502` upstream unavailable/proxy failure
 
 ## Notes

--- a/gateway/internal/adapters/inbound/http/race_parameter_middleware.go
+++ b/gateway/internal/adapters/inbound/http/race_parameter_middleware.go
@@ -1,0 +1,201 @@
+// Package httpinbound contains inbound HTTP handlers, middleware, and proxy adapters.
+
+package httpinbound
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+var allowedRaceSessionDatasets = map[string]struct{}{
+	"laps":                 {},
+	"car_data":             {},
+	"telemetry":            {},
+	"location":             {},
+	"position":             {},
+	"intervals":            {},
+	"stints":               {},
+	"pit":                  {},
+	"pit_stops":            {},
+	"weather":              {},
+	"team_radio":           {},
+	"overtakes":            {},
+	"race_control":         {},
+	"session_result":       {},
+	"starting_grid":        {},
+	"championship_drivers": {},
+	"championship_teams":   {},
+}
+
+var allowedRaceDriverDatasets = map[string]struct{}{
+	"laps":      {},
+	"telemetry": {},
+	"location":  {},
+	"position":  {},
+	"intervals": {},
+	"stints":    {},
+	"pit":       {},
+	"radio":     {},
+	"result":    {},
+}
+
+// These are dedicated driver endpoints sharing the same 7-segment path shape
+// as /drivers/{driverNumber}/{dataset}.
+var allowedRaceDriverActions = map[string]struct{}{
+	"profile":   {},
+	"broadcast": {},
+}
+
+// ValidateRaceParameters validates selected public /v1/race parameters at the gateway edge.
+func ValidateRaceParameters(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		parts := splitPath(r.URL.Path)
+		if len(parts) == 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if dataset, ok := extractRaceSessionDataset(parts); ok {
+			if _, allowed := allowedRaceSessionDatasets[dataset]; !allowed {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid parameter"})
+				return
+			}
+		}
+
+		if segment, ok := extractRaceDriverSegment(parts); ok {
+			if !isAllowedRaceDriverSegment(segment) {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid parameter"})
+				return
+			}
+		}
+
+		if driverNumber, ok := extractRaceDriverNumber(parts); ok && !isPositiveInt(driverNumber) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid parameter"})
+			return
+		}
+
+		if lapNumber, ok := extractRaceLapNumber(parts); ok && !isPositiveInt(lapNumber) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid parameter"})
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func splitPath(path string) []string {
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+func extractRaceSessionDataset(parts []string) (string, bool) {
+	if len(parts) != 6 {
+		return "", false
+	}
+
+	if parts[0] != "v1" || parts[1] != "race" || parts[2] != "sessions" || parts[4] != "datasets" {
+		return "", false
+	}
+
+	if strings.TrimSpace(parts[3]) == "" || strings.TrimSpace(parts[5]) == "" {
+		return "", false
+	}
+
+	return strings.TrimSpace(parts[5]), true
+}
+
+func extractRaceDriverSegment(parts []string) (string, bool) {
+	if len(parts) != 7 {
+		return "", false
+	}
+
+	if parts[0] != "v1" || parts[1] != "race" || parts[2] != "sessions" || parts[4] != "drivers" {
+		return "", false
+	}
+
+	if strings.TrimSpace(parts[3]) == "" || strings.TrimSpace(parts[5]) == "" {
+		return "", false
+	}
+
+	segment := strings.TrimSpace(parts[6])
+	if segment == "" {
+		return "", false
+	}
+
+	return segment, true
+}
+
+func isAllowedRaceDriverSegment(segment string) bool {
+	if _, allowed := allowedRaceDriverDatasets[segment]; allowed {
+		return true
+	}
+
+	_, allowed := allowedRaceDriverActions[segment]
+	return allowed
+}
+
+func extractRaceDriverNumber(parts []string) (string, bool) {
+	if len(parts) < 7 {
+		return "", false
+	}
+
+	if parts[0] != "v1" || parts[1] != "race" || parts[2] != "sessions" || parts[4] != "drivers" {
+		return "", false
+	}
+
+	if strings.TrimSpace(parts[3]) == "" {
+		return "", false
+	}
+
+	driverNumber := strings.TrimSpace(parts[5])
+	if driverNumber == "" {
+		return "", false
+	}
+
+	return driverNumber, true
+}
+
+func extractRaceLapNumber(parts []string) (string, bool) {
+	if len(parts) != 9 {
+		return "", false
+	}
+
+	if parts[0] != "v1" ||
+		parts[1] != "race" ||
+		parts[2] != "sessions" ||
+		parts[4] != "drivers" ||
+		parts[6] != "laps" ||
+		parts[8] != "location" {
+		return "", false
+	}
+
+	if strings.TrimSpace(parts[3]) == "" || strings.TrimSpace(parts[5]) == "" {
+		return "", false
+	}
+
+	lapNumber := strings.TrimSpace(parts[7])
+	if lapNumber == "" {
+		return "", false
+	}
+
+	return lapNumber, true
+}
+
+func isPositiveInt(raw string) bool {
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return false
+	}
+
+	return value > 0
+}

--- a/gateway/internal/adapters/inbound/http/router.go
+++ b/gateway/internal/adapters/inbound/http/router.go
@@ -42,6 +42,11 @@ func NewHandler(
 			serviceHandler = ValidateChampionshipDataset(serviceHandler)
 		}
 
+		if prefix == "/v1/race" {
+			// Explicit edge validation for race dataset and numeric route parameters.
+			serviceHandler = ValidateRaceParameters(serviceHandler)
+		}
+
 		protected := RequireAuthorization(authorizeUseCase.Execute, serviceHandler)
 		mux.Handle(prefix, protected)
 		mux.Handle(prefix+"/", protected)

--- a/gateway/internal/config/routes_race_data.go
+++ b/gateway/internal/config/routes_race_data.go
@@ -9,6 +9,7 @@ func raceDataServiceRoutes(targets upstreamTargets) serviceRoutes {
 		proxied: map[string][]*url.URL{
 			"/race-data": targets.raceData,
 			"/races":     targets.raceData,
+			"/v1/race":   targets.raceData,
 		},
 		health: map[string][]*url.URL{
 			"/health/race-data": targets.raceData,


### PR DESCRIPTION
## Context
This PR exposes `race-data-service` through the gateway under `/v1/race/*`
Closes #38 — `/v1/race/` exposure

## Changes

### race-data-service exposure
- Routed all `/v1/race/*` requests to `RACE_DATA_SERVICE_URLS`
- **Catalog** (internal proxy façade to `championship-service`): `/championships`, `/championships/{code}/events`, `/events/{eventId}`, `/events/{eventId}/sessions`
- **Session — metadata & references**: `/sessions/{sessionId}` and sub-resources (`metadata`, `drivers`, `teams`)
- **Session — data & shortcuts**: datasets, standings/race, broadcast, weather, facts
- **Driver routes**: profile, broadcast, per-driver datasets (`laps`, `telemetry`, `location`, `position`, `intervals`, `stints`, `pit`, `radio`, `result`), and lap-level location
- **WebSocket live**: `WS /v1/race/live?sessionId={sessionId}` — snapshot/delta/heartbeat semantics with mandatory `seq` field

### Edge validation middleware
- Wired race-specific validation middleware on the `/v1/race` prefix
- Session dataset route: validates `{dataset}` against allowed values
- Driver segment route: validates `{segment}` against allowed values (`profile` and `broadcast` accepted on same path shape)
- Numeric param validation on `driverNumber` and `lapNumber`
- Gateway error contract enforced: `400 { "error": "invalid parameter" }` on invalid inputs